### PR TITLE
Change so errrors are more descriptive for login and sign up

### DIFF
--- a/frontend/src/Components/LoginSignup/LoginSignup.jsx
+++ b/frontend/src/Components/LoginSignup/LoginSignup.jsx
@@ -46,7 +46,7 @@ const LoginSignup = ({ setCurrentUser }) => {
             }
           })
           .catch(error => {
-            toast.error("Error logging in. " + error.message)
+            toast.error("Error logging in - " + error.response.data['error']);
             if (error.response) {
               console.error('Error response data:', error.response.data);
               console.error('Error status:', error.response.status);
@@ -83,7 +83,7 @@ const LoginSignup = ({ setCurrentUser }) => {
             } 
           })
           .catch(error => {
-            toast.error("Sign In Error.");
+            toast.error("Error signing up - " + error.response.data['error']);
 
             if (error.response) {
               console.error('Error response data:', error.response.data);


### PR DESCRIPTION
Toast now shows the returned error messages from the server with errors like invalid password, username not found for login and errors like missing username, email, or password and username is already taken for signing up.